### PR TITLE
fix(test): Use system property to get the project path.

### DIFF
--- a/src/test/java/top/zhogjianhao/junit/FileUtilsTest.java
+++ b/src/test/java/top/zhogjianhao/junit/FileUtilsTest.java
@@ -11,10 +11,8 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 @Slf4j
 @DisplayName("文件工具类测试")
 public class FileUtilsTest {
-
-  private static final String HOME_PATH = "C:\\Users\\duanluan";
-  private static final String PROJECT_PATH = "E:\\duanluan\\WorkSpaces\\My\\ZUtil";
-  private static final String PROJECT_PATH_SLASH = "/E:/duanluan/WorkSpaces/My/ZUtil";
+  private static final String PROJECT_PATH = System.getProperty("user.dir");
+  private static final String PROJECT_PATH_SLASH = System.getProperty("user.dir").replace("\\", "/");
 
   public static void main(String[] args) {
     System.out.println(FileUtils.getClassRootPath());


### PR DESCRIPTION
Fix: https://github.com/duanluan/ZUtil/issues/6

## Motivation

See https://github.com/duanluan/ZUtil/issues/6

## Modification

We need to use `System.getProperty("user.dir")` to get the current project path.

In this way, we need to make sure we are running the maven command in the correct path. This may cause some inconvenience for the developer. I think it's better to find a good way to refactor this test.

